### PR TITLE
Feature basic mock service

### DIFF
--- a/demodata/init_cheese_object.json
+++ b/demodata/init_cheese_object.json
@@ -1,4 +1,4 @@
 {
     "product":"cheese",
-    "attributes":["Quality","barcode","lotid","bestbeforedate","state"]
+    "attributes":["Quality","barcode","lotid","bestbeforedate","state","Documents"]
 }

--- a/demodata/init_documents_attribute.json
+++ b/demodata/init_documents_attribute.json
@@ -1,0 +1,4 @@
+{
+    "attribute":"Documents",
+    "attrValue":"String"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1869,6 +1869,30 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react": "^16.9.49",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
+    "axios-mock-adapter": "^1.19.0",
     "eslint": "6.8.0",
     "eslint-config-airbnb": "18.1.0",
     "eslint-config-prettier": "6.10.1",

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,12 +1,18 @@
 import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import * as jwt from "jsonwebtoken";
 
-const instance = axios.create({
+const ONE_HOUR_IN_SECONDS:number = 3600;
+
+const useMockedBackend: boolean = process.env.NEXT_PUBLIC_USE_MOCKED_BACKEND === "TRUE" ? true : false;
+
+const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
   timeout: 20000,
   headers: {},
 });
 
-instance.interceptors.response.use(
+axiosInstance.interceptors.response.use(
   (response) => {
     if (response.status === 401) {
       alert("You are not authorized (401)");
@@ -23,5 +29,70 @@ instance.interceptors.response.use(
     return Promise.reject(error.message);
   }
 );
+/* Mock REST API customized responses sections starts below (only used is NEXT_PUBLIC_USE_MOCKED_BACKEND is set to TRUE) */
+if ( useMockedBackend ) {
+  var mockHelper = new MockAdapter(axiosInstance);
 
-export default instance;
+  var mockJWTToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImF1dGhvcml0aWVzIjpbIlJPTEVfQURNSU4iLCJST0xFX01FTUJFUiIsIlJPTEVfVVNFUiJdLCJpYXQiOjE2MTA0Mzk4MTEsImV4cCI6MTYxMDQ0MzQxMX0.LHo2UIlZt3aD-mQ4uQ7xsmD_2sqCzS3zzcxj7GUnY-4";
+  var decodedJWTToken = jwt.decode(mockJWTToken, { complete: true }) as any;
+  //TODO: maybe deep copy the damn payload...
+  var newTOken = jwt.sign({
+    payload: {...decodedJWTToken.payload},
+    exp: Math.floor(Date.now() / 1000 + ONE_HOUR_IN_SECONDS)
+  },'secret');
+  
+  
+  mockHelper.onPost("/auth").reply(200,
+    {
+      "username":"admin",
+      "token": mockJWTToken,
+      "date": decodedJWTToken.payload.exp
+    }
+  );
+  
+  mockHelper.onGet("/get",{ params: { function: "META_readMetaDef" } }).reply(200,
+    {
+      "productNameToAttributesMap": {
+        "milk": [
+            "Quality"
+        ],
+        "delivery": [
+            "barcode",
+            "lotid",
+            "bestbeforedate",
+            "state"
+        ],
+        "fresh_milk": [
+            "barcode",
+            "lotid",
+            "bestbeforedate",
+            "state"
+        ],
+        "cheese": [
+            "Quality",
+            "barcode",
+            "lotid",
+            "bestbeforedate",
+            "state"
+        ]
+    },
+    "unitList": [
+        "Liter",
+        "Package"
+    ],
+    "attributeToDataTypeMap": {
+        "light": "String",
+        "Quality": "Integer",
+        "cows": "Integer",
+        "bestbeforedate": "String",
+        "lotid": "Integer",
+        "state": "String",
+        "barcode": "String",
+        "Protein": "Integer"
+    }
+    }
+  );
+}
+
+
+export default axiosInstance;

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -35,17 +35,15 @@ if ( useMockedBackend ) {
 
   var mockJWTToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImF1dGhvcml0aWVzIjpbIlJPTEVfQURNSU4iLCJST0xFX01FTUJFUiIsIlJPTEVfVVNFUiJdLCJpYXQiOjE2MTA0Mzk4MTEsImV4cCI6MTYxMDQ0MzQxMX0.LHo2UIlZt3aD-mQ4uQ7xsmD_2sqCzS3zzcxj7GUnY-4";
   var decodedJWTToken = jwt.decode(mockJWTToken, { complete: true }) as any;
-  //TODO: maybe deep copy the damn payload...
-  var newTOken = jwt.sign({
-    payload: {...decodedJWTToken.payload},
-    exp: Math.floor(Date.now() / 1000 + ONE_HOUR_IN_SECONDS)
-  },'secret');
+  //Change the time so that the token is valid and simply sign with secret (validation is not required in offline mode)
+  decodedJWTToken.payload.exp = Math.floor(Date.now() / 1000 + ONE_HOUR_IN_SECONDS);
+  var newTOken = jwt.sign( decodedJWTToken,'secret');
   
   
   mockHelper.onPost("/auth").reply(200,
     {
       "username":"admin",
-      "token": mockJWTToken,
+      "token": newTOken,
       "date": decodedJWTToken.payload.exp
     }
   );

--- a/src/components/base/controls/ConnectionStateIcon.tsx
+++ b/src/components/base/controls/ConnectionStateIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import CancelOutlinedIcon from "@material-ui/icons/CancelOutlined";
+import CheckCircleRoundedIcon from "@material-ui/icons/CheckCircle";
+import { Tooltip } from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
+
+export interface ConnectionStateProps {
+    isOffline: boolean;
+}
+export default function ConnectionStateIcon(props: ConnectionStateProps) {
+    const offlineTooltipText = "Currently working offline";
+    const onlineTooltipText = "Currently working online";
+    let tooltipText = props.isOffline ? offlineTooltipText : onlineTooltipText;
+    return(      
+        <Tooltip title={tooltipText}>
+            <IconButton
+              aria-label="API status"
+              color="inherit"
+            >
+                {props.isOffline ? (
+                    <CancelOutlinedIcon />
+                 ) : (
+                    <CheckCircleRoundedIcon />
+                 )
+                }
+            </IconButton>
+          </Tooltip>
+    );
+}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -24,6 +24,7 @@ import CreateIcon from "@material-ui/icons/Create";
 import userService from "../services/user-service";
 import ConnectionStateIcon from "../base/controls/ConnectionStateIcon";
 import axiosMetricsInstance from "../../prometheusAxios";
+import { resolveNaptr } from "dns";
 
 export default function MainLayout(props) {
   const SECONDS_TO_WAIT_BETWEEN_STATUSCHECKS = 5;
@@ -49,8 +50,14 @@ export default function MainLayout(props) {
       console.log("Got 2xx response");
       setIsHyperledgerAvailable(true);
     }).catch((reason) => {
-      console.log("Endpoint query failed")
-      setIsHyperledgerAvailable(false);
+      if (reason.response && reason.response.status !== 500 ) {
+        setIsHyperledgerAvailable(true);
+      } else {
+        console.log("Endpoint query failed");
+        setIsHyperledgerAvailable(true);
+      }
+      
+      
     });
   
     const timeout = setTimeout(() => {

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -45,19 +45,17 @@ export default function MainLayout(props) {
 
   //This is a continual check so it triggers every X seconds (see constant) while the app is running
   useEffect(() => {
-    axiosMetricsInstance.get("/api/v1/query").
+    axiosMetricsInstance.get("/api/v1/query",{params: {query:"fabric_version"}}).
     then((response) => {
-      console.log("Got 2xx response");
       setIsHyperledgerAvailable(true);
     }).catch((reason) => {
-      if (reason.response && reason.response.status !== 500 ) {
+      if (reason.response && reason.response.status ) {
+        //usually 4XX or 5XX errors, but that only means that there is an issue with prometheus, not necessarily with fabric itself
         setIsHyperledgerAvailable(true);
       } else {
-        console.log("Endpoint query failed");
-        setIsHyperledgerAvailable(true);
-      }
-      
-      
+        console.log("Endpoint query failed with status: " + reason);
+        setIsHyperledgerAvailable(false);
+      }  
     });
   
     const timeout = setTimeout(() => {

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -22,6 +22,7 @@ import { useRouter } from "next/router";
 import { useStyles, useTheme } from "./styles";
 import CreateIcon from "@material-ui/icons/Create";
 import userService from "../services/user-service";
+import ConnectionStateIcon from "../base/controls/ConnectionStateIcon";
 
 export default function MainLayout(props) {
   const classes = useStyles();
@@ -72,6 +73,8 @@ export default function MainLayout(props) {
           >
             NutriSafe Producer Dashboard
           </Typography>
+          <div className={classes.grow} />
+          <ConnectionStateIcon isOffline={userService.isInOfflineMode()} />  
           {userService.isLoggedIn() ? (
             <Button
               color="inherit"

--- a/src/components/layout/styles.ts
+++ b/src/components/layout/styles.ts
@@ -32,6 +32,9 @@ const useStyles = makeStyles((theme: Theme) =>
     hide: {
       display: "none",
     },
+    grow: {
+      flexGrow: 1,
+    },
     drawer: {
       width: drawerWidth,
       flexShrink: 0,

--- a/src/components/services/user-service.tsx
+++ b/src/components/services/user-service.tsx
@@ -1,6 +1,7 @@
 import instance from "../../axios";
 import * as jwt from "jsonwebtoken";
 
+
 class AuthService {
   login(username, password) {
     return instance
@@ -36,6 +37,10 @@ class AuthService {
     }
   }
 
+  isInOfflineMode(): boolean {
+     return process.env.NEXT_PUBLIC_USE_MOCKED_BACKEND === "TRUE" ? true : false;
+  }
+  
   hasRole(role: string): boolean {
     if (typeof window === "object") {
       const encodedJWT = localStorage.getItem("JWT");

--- a/src/prometheusAxios.ts
+++ b/src/prometheusAxios.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+
+const ONE_HOUR_IN_SECONDS:number = 3600;
+
+
+const axiosMetricsInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_PROMETHEUS_API_URL,
+  timeout: 20000,
+  headers: {},
+});
+
+axiosMetricsInstance.interceptors.response.use(
+  (response) => {
+    if (response.status === 401) {
+      alert("You are not authorized (401)");
+    }
+    if (response.status === 403) {
+      alert("You are not authorized for this action (403)");
+    }
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.data) {
+      return Promise.reject(error.response.data);
+    }
+    return Promise.reject(error.message);
+  }
+);
+
+
+export default axiosMetricsInstance;

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 echo "NEXT_PUBLIC_COMPANY_NAME=$NEXT_PUBLIC_COMPANY_NAME" > .env.production
 echo "NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL" >> .env.production
+echo "NEXT_PUBLIC_USE_MOCKED_BACKEND=$NEXT_PUBLIC_USE_MOCKED_BACKEND" >> .env.production
+echo "NEXT_PUBLIC_PROMETHEUS_API_URL=$NEXT_PUBLIC_PROMETHEUS_API_URL" >> .env.production
 npm run build-start


### PR DESCRIPTION
Introduced mocking function for the REST API so that the Frontend can run without the backend. This PR thus closes #2 
Also added is the Prometheus-connection to the backend referenced in #32. This PR closes #32 as well.

The mocking function is limited for now to the meta info and login pages. If you are in forced offline mode (See below) you can log in with any random combination of username and password because the login request is no longer sent to the backend. This functionality will be extended in upcoming PRs.

Offline mode can be controlled by the environment variable in the file .env.* and for Docker container deployments
NEXT_PUBLIC_USE_MOCKED_BACKEND=TRUE -> Offline mode forced (sample data only)

If NEXT_PUBLIC_PROMETHEUS_API_URL is also defined (e.g. NEXT_PUBLIC_PROMETHEUS_API_URL=http://localhost:9090) the Dashboard attempts to make a GET request every X seconds (configurable) and sets the icon correspondingly if it gets a response or not. 