### PR TITLE
Changed node image to alpine and error fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.15.5-alpine
 
 WORKDIR /producer-dashboard
 # Install app dependencies
@@ -7,7 +7,7 @@ COPY ["package.json", "package-lock.json*", "./"]
 
 # RUN rm -rf node_modules
 RUN rm -rf .next && rm package-lock.json
-RUN apt-get update && apt install git -y && git --version && npm install --silent
+RUN npm install --silent
 # We need to build the dashboard itself so if there are any errors the docker image publishing will fail
 RUN npm run build
 RUN chmod u+x ./start.sh

--- a/src/components/goods/product-stock.tsx
+++ b/src/components/goods/product-stock.tsx
@@ -165,7 +165,7 @@ const ProductStock = () => {
   }, []);
 
   function updateItems() {
-    productService.productStock().then((res) => {
+    productService.productStock().then((res:any) => {
       let array: StockItem[] = [];
       res.data.map((element) => {
         array.push(JSON.parse(element));


### PR DESCRIPTION
This is related to #35 as it is relevant to a quick and efficient build pipeline.
As suggested by Prabhakar there is an even better image for node:14 -> node:14.15.5-alpine This considerably reduces the size of containers and the time it takes to build

